### PR TITLE
Use `Promise.resolve()` to simplify `nextFrame.mapInFrames`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+yarn.lock

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var nextFrame = require('../index');
+
+it('nextFrame', function() {
+  var result = 1;
+  return nextFrame().then(() => {
+    expect(result).toBe(1);
+  });
+});
+
+it('nextFrame.mapInFrames', function() {
+  return nextFrame.mapInFrames([1, 2, 3], val => val * 2).then(
+    results => expect(results).toEqual([2, 4, 6])
+  );
+});

--- a/index.js
+++ b/index.js
@@ -8,27 +8,12 @@ function nextFrame() {
 
 /* Applies `fn` to each element of `collection`, iterating once per frame */
 nextFrame.mapInFrames = function(collection, fn) {
-  var results = [];
-
-  return new Promise(function(resolve, reject) {
-    var processEntry = function(index) {
-      if (index < collection.length) {
-        requestAnimationFrame(function() {
-          try {
-            results.push(fn(collection[index]));
-            processEntry(index+1);
-          } catch(e) {
-            reject(e);
-          }
-        })
-      }
-      else {
-        resolve(results);
-      }
-    };
-
-    processEntry(0);
+  var queue = Promise.resolve();
+  var values = [];
+  collection.forEach(item => {
+    queue = queue.then(() => nextFrame().then(() => values.push(fn(item))));
   });
+  return queue.then(() => values);
 }
 
 module.exports = nextFrame;

--- a/jest/env.js
+++ b/jest/env.js
@@ -1,0 +1,3 @@
+global.requestAnimationFrame = function(callback) {
+  callback();
+};

--- a/package.json
+++ b/package.json
@@ -4,11 +4,16 @@
   "description": "Returns a promise that resolves on the next animationFrame",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/corbt/next-frame.git"
+  },
+  "jest": {
+    "setupFiles": [
+      "jest/env.js"
+    ]
   },
   "keywords": [
     "promise",
@@ -21,5 +26,8 @@
   "bugs": {
     "url": "https://github.com/corbt/next-frame/issues"
   },
-  "homepage": "https://github.com/corbt/next-frame#readme"
+  "homepage": "https://github.com/corbt/next-frame#readme",
+  "devDependencies": {
+    "jest": "^16.0.2"
+  }
 }


### PR DESCRIPTION
Promise.resolve does a lot of the queueing magic that was formally in `mapInFrames`, using that simplifies the code somewhat.

Added a jest test to sanity check the result is the same, run using `npm test`.
